### PR TITLE
Uploads JaCoCo report to artifact storage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,17 @@ jobs:
           ls -la target/site || true;
           ls -la target/site/jacoco || true
 
+      - name: Print jacoco xml head (if exists)
+        run: |
+          if [ -f target/site/jacoco/jacoco.xml ]; then echo "--- jacoco.xml head ---"; head -n 60 target/site/jacoco/jacoco.xml; else echo "jacoco.xml not found"; fi
+
+      - name: Upload jacoco report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/jacoco.xml
+          if-no-files-found: warn
+
       - name: Check SONAR_TOKEN presence
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -61,10 +72,10 @@ jobs:
       - name: Run SonarCloud analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
-          -Dsonar.projectKey=RdzJJ_SonnarCloud_QA \
+        run: mvn -Dsonar.projectKey=RdzJJ_SonnarCloud_QA \
           -Dsonar.organization=rdzijj \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ env.SONAR_TOKEN }} \
           -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml \
-          -Dsonar.verbose=true
+          -Dsonar.verbose=true \
+          org.sonarsource.scanner.maven:sonar-maven-plugin:sonar


### PR DESCRIPTION
Configures the build process to upload the JaCoCo XML report as an artifact. This allows for easier access and analysis of the code coverage data generated during the build. Also prints the head of the jacoco xml to aid debugging.